### PR TITLE
Button: support custom amounts

### DIFF
--- a/actblue-contributions/blocks/custom/actblue-button/edit.js
+++ b/actblue-contributions/blocks/custom/actblue-button/edit.js
@@ -86,7 +86,14 @@ function ActBlueButtonEdit({
 	setAttributes,
 	className,
 }) {
-	const { borderRadius, placeholder, text, endpoint, refcode } = attributes;
+	const {
+		borderRadius,
+		placeholder,
+		text,
+		endpoint,
+		refcode,
+		amount,
+	} = attributes;
 
 	const [isFetching, setIsFetching] = useState(false);
 	const [fetchMessage, setFetchMessage] = useState("");
@@ -211,17 +218,15 @@ function ActBlueButtonEdit({
 						help="Associate contributions made through this button with a refcode."
 					/>
 
-					{/*
-					We can add a field for an `Amount` with another text control. We can grab the
-					`amount` variable from the attributes passed to this edit function.
-					*/}
-
-					{/* <TextControl
+					<TextControl
 						type="number"
 						label="Amount"
-						value={amount}
-						onChange={(value) => setAttributes({ amount: value })}
-					/> */}
+						value={amount / 100}
+						onChange={(value) =>
+							setAttributes({ amount: value * 100 })
+						}
+						help="Set the amount of the contribution in dollars, leave blank to let the donor choose an amount."
+					/>
 				</PanelBody>
 				<PanelColorGradientSettings
 					title={__("Background & Text Color")}

--- a/actblue-contributions/blocks/custom/actblue-button/index.js
+++ b/actblue-contributions/blocks/custom/actblue-button/index.js
@@ -65,15 +65,9 @@ const attributes = {
 		type: "string",
 	},
 
-	/**
-	 * Uncommend the following attribute to enable a user to attach a specific donation
-	 * amount to a button. You can then access this `amount` variable in the attributes
-	 * parameter passed to the edit.js and save.js functions. This is required so that
-	 * the amount value gets saved to the block.
-	 */
-	// amount: {
-	// 	type: "string",
-	// },
+	amount: {
+		type: "number",
+	},
 };
 
 export const name = "actblue/button";

--- a/actblue-contributions/blocks/custom/actblue-button/save.js
+++ b/actblue-contributions/blocks/custom/actblue-button/save.js
@@ -14,6 +14,7 @@ import {
 
 const ActBlueButtonSave = ({ attributes }) => {
 	const {
+		amount,
 		backgroundColor,
 		borderRadius,
 		customBackgroundColor,
@@ -72,6 +73,7 @@ const ActBlueButtonSave = ({ attributes }) => {
 				target="_blank"
 				data-token={token}
 				data-refcode={refcode}
+				data-amount={amount}
 				rel="noopener noreferrer"
 			/>
 		</div>

--- a/actblue-contributions/public/js/actblue-contributions.js
+++ b/actblue-contributions/public/js/actblue-contributions.js
@@ -24,7 +24,8 @@ const onDocumentReady = (callback) => {
  * @return void
  */
 const handleButtonClick = (event) => {
-	const { token, refcode } = event.currentTarget.dataset;
+	const { currentTarget } = event;
+	const { token, refcode, amount } = currentTarget.dataset;
 
 	if (!token) {
 		console.warn(
@@ -33,7 +34,11 @@ const handleButtonClick = (event) => {
 		return;
 	}
 
-	window.actblue.requestContribution({ token, refcodes: { refcode } });
+	window.actblue.requestContribution({
+		token,
+		amount,
+		refcodes: { refcode },
+	});
 	event.preventDefault();
 };
 
@@ -43,9 +48,10 @@ const handleButtonClick = (event) => {
  * @return void
  */
 const actblueInit = () => {
+	const { actblue } = window;
 	if (
-		typeof window.actblue !== "object" ||
-		typeof window.actblue.requestContribution !== "function"
+		typeof actblue !== "object" ||
+		typeof actblue.requestContribution !== "function"
 	) {
 		console.warn("The actblue.js script is not loaded, but is required.");
 		return;


### PR DESCRIPTION
thanks to upstatement for teeing this one up:

support custom amounts for buttons, so that site admins can have a `Give 5$` button or whatever

<img width="271" alt="image" src="https://user-images.githubusercontent.com/18301/102513726-90c48f80-4059-11eb-99c8-b93597aa42d7.png">
