### PR TITLE
buttons: remove deprecated experimental component

### DIFF
--- a/actblue-contributions/blocks/custom/actblue-buttons/edit.js
+++ b/actblue-contributions/blocks/custom/actblue-buttons/edit.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
-	InnerBlocks,
-} from "@wordpress/block-editor";
+import { InnerBlocks } from "@wordpress/block-editor";
 
 const ALLOWED_BLOCKS = ["actblue/button"];
 const BUTTONS_TEMPLATE = [["actblue/button"]];
@@ -12,22 +9,15 @@ const UI_PARTS = {
 	hasSelectedUI: false,
 };
 
-// Inside buttons block alignment options are not supported.
-const alignmentHooksSetting = {
-	isEmbedButton: true,
-};
-
 function ActBlueButtonsEdit({ className }) {
 	return (
 		<div className={`${className} wp-block-buttons`}>
-			<AlignmentHookSettingsProvider value={alignmentHooksSetting}>
-				<InnerBlocks
-					allowedBlocks={ALLOWED_BLOCKS}
-					template={BUTTONS_TEMPLATE}
-					__experimentalUIParts={UI_PARTS}
-					__experimentalMoverDirection="horizontal"
-				/>
-			</AlignmentHookSettingsProvider>
+			<InnerBlocks
+				allowedBlocks={ALLOWED_BLOCKS}
+				template={BUTTONS_TEMPLATE}
+				__experimentalUIParts={UI_PARTS}
+				__experimentalMoverDirection="horizontal"
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
it seems to be copied in from the gutenburg button implementation, but it's been removed in 5.7 and everything seems to work without it