### PR TITLE
Bump version to 1.5.1

### DIFF
--- a/actblue-contributions/actblue-contributions.php
+++ b/actblue-contributions/actblue-contributions.php
@@ -14,7 +14,7 @@
  * License URI:      http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:      actblue
  * Domain Path:      /languages
- * Version:          1.5.0
+ * Version:          1.5.1
  */
 
 // If this file is called directly, abort.
@@ -25,7 +25,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Current plugin version.
  */
-define( 'ACTBLUE_PLUGIN_VERSION', '1.5.0' );
+define( 'ACTBLUE_PLUGIN_VERSION', '1.5.1' );
 
 /**
  * Defines the ActBlue host.

--- a/actblue-contributions/composer.json
+++ b/actblue-contributions/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "actblue/actblue-contributions-wp-plugin",
   "type": "wordpress-plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "authors": [],
   "description": "Easily embed your ActBlue contribution forms on any WordPress page",
   "require": {

--- a/actblue-contributions/e2e-tests/embed-block.spec.js
+++ b/actblue-contributions/e2e-tests/embed-block.spec.js
@@ -45,7 +45,7 @@ describe("Wrapper block", () => {
 		await embedBtn.click();
 
 		// wait for 1 second for the embed to load.
-		await page.waitFor(1000);
+		await page.waitForTimeout(1000);
 
 		expect(await getEditedPostContent()).toMatchSnapshot();
 	});

--- a/actblue-contributions/package.json
+++ b/actblue-contributions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actblue-contributions",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "ActBlue",
   "scripts": {
     "build": "wp-scripts build --config webpack.config.js",

--- a/actblue-contributions/readme.txt
+++ b/actblue-contributions/readme.txt
@@ -5,7 +5,7 @@ Tags: donate,donation,fundraising,giving,charity,nonprofit,contribute,contributi
 Requires at least: 4.5
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,7 +101,7 @@ If you have a question about the ActBlue platform, visit our [support site](http
 
 == Changelog ==
 
-= 1.5.0 =
+= 1.5.1 =
 * Tested up to Wordpress 5.8.1
 * Provide data-ab-source attribute to actblue.js script tag
 


### PR DESCRIPTION
Essentially we're re-releasing 1.5.0 / 1.5.0.1 changes since they didn't get synced correctly to Wordpress SVN.